### PR TITLE
docs: add root AGENTS and SPEC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Programmatic-PID Agent Notes
+
+## Scope
+
+This repository generates P&ID drawings from YAML specifications. The maintained code lives under `src/programmatic_pid`, with tests in `tests/`, schemas in `schema/`, examples in `examples/`, and generated drawings in `output/`.
+
+## Working Rules
+
+- Keep changes aligned with the current package layout and public CLI entrypoint `generate-pid`.
+- Prefer small, targeted edits. Do not widen a docs task into implementation refactors unless the documentation is wrong without them.
+- Preserve backward-compatible imports from `programmatic_pid.generator` unless a task explicitly says otherwise.
+- Treat generated files, caches, and build artifacts as disposable unless a specific task says to promote them to fixtures.
+- Do not edit unrelated files or revert user changes.
+
+## Validation
+
+- Use the repo-standard test and lint commands for code changes: `pytest`, `ruff`, `black`, and `mypy` when relevant to the task.
+- For documentation-only changes, run a lightweight repo sanity check and confirm the docs still match the current layout.
+
+## Documentation
+
+- Keep `SPEC.md` truthful. If the implementation changes, update the spec in the same workstream.
+- Keep the README, spec, and repo layout consistent enough that another engineer can find the CLI, schema, tests, and generated outputs quickly.
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,63 @@
+# Programmatic-PID Specification
+
+## Purpose
+
+`Programmatic-PID` is a Python package for generating editable P&ID drawings from YAML specifications. It produces DXF output and optional SVG previews for review and drafting workflows.
+
+## Public Entry Point
+
+- CLI script: `generate-pid`
+- Module entrypoint: `programmatic_pid.generator:main`
+- Core orchestration module: `src/programmatic_pid/generator.py`
+
+## Repository Layout
+
+- `src/programmatic_pid/` contains the maintained package code.
+- `tests/` contains unit and integration tests for the package.
+- `schema/pid_spec.schema.json` provides YAML schema support for editor validation.
+- `examples/biochar/` contains example specifications used for manual and automated verification.
+- `output/` is the local generation target directory for drawings and previews.
+- `docs/` holds engineering notes and related documentation.
+
+## Runtime Responsibilities
+
+- `validator.py` validates YAML spec structure and raises `SpecValidationError` for invalid inputs.
+- `generator.py` loads specs, applies profiles, computes layout, and orchestrates sheet generation.
+- `dxf_builder.py` provides drawing primitives, geometry helpers, and layer utilities.
+- `stream_router.py` routes process streams between equipment anchors and handles labeling.
+- `control_loops.py` draws control-loop relationships and reference routing.
+- `notes.py` renders notes, mass balance values, and sheet annotations.
+
+## Configuration Model
+
+The YAML spec is the source of truth. The common top-level sections are:
+
+- `project`
+- `equipment`
+- `streams`
+- `instruments`
+- `control_loops`
+- `interlocks`
+- `defaults`
+- `drawing`
+
+The package also supports layout profiles such as `review`, `presentation`, and `compact`, which are applied as overlay configuration before drawing.
+
+## Output Contract
+
+- Process sheet generation writes a primary DXF file and may emit an SVG preview.
+- Two-sheet generation also writes a controls/interlocks DXF and optional SVG preview.
+- Generated artifacts belong in `output/` or another caller-supplied path, not in tracked source directories.
+
+## Testing And Validation
+
+- Unit tests cover validation, geometry helpers, routing, notes, and orchestration behavior.
+- Integration tests exercise end-to-end generation from example specs.
+- The repo expects packaging-compatible imports from `src/` rather than ad hoc path manipulation.
+
+## Maintenance Notes
+
+- Backward-compatible imports from `programmatic_pid.generator` are part of the current contract.
+- Documentation should remain consistent with the real package layout and public CLI behavior.
+- If a future change moves responsibility between modules, update this spec in the same change.
+


### PR DESCRIPTION
Closes #29\n\nAdds root-level agent guidance and a truthful spec aligned to the current Programmatic-PID package layout, CLI entrypoint, tests, and generated-output conventions.\n\nValidation: python -m pytest