### PR TITLE
[codex] Fail fast on stream rendering errors

### DIFF
--- a/src/programmatic_pid/sheet_rendering.py
+++ b/src/programmatic_pid/sheet_rendering.py
@@ -266,24 +266,21 @@ def _draw_process_streams(
     """Draw process streams and return resolved stream label anchor points."""
     stream_points: dict[str, tuple[float, float]] = {}
     for stream in spec.get("streams", []):
-        try:
-            stream_point = add_stream(
-                msp,
-                stream,
-                text_h=text_cfg["small_height"],
-                text_layer=text_layer,
-                equipment_by_id=equipment_by_id,
-                arrow_size=arrow_size,
-                label_scale=layout_cfg["stream_label_scale"],
-                label_placer=label_placer,
-                draw_label_leader=layout_cfg["stream_label_leaders"],
-                leader_layer=leader_layer,
-            )
-            stream_id = stream.get("id")
-            if stream_id and stream_point:
-                stream_points[stream_id] = stream_point
-        except Exception as exc:
-            logger.warning("Skipped stream %s: %s", stream.get("id", "<unknown>"), exc)
+        stream_point = add_stream(
+            msp,
+            stream,
+            text_h=text_cfg["small_height"],
+            text_layer=text_layer,
+            equipment_by_id=equipment_by_id,
+            arrow_size=arrow_size,
+            label_scale=layout_cfg["stream_label_scale"],
+            label_placer=label_placer,
+            draw_label_leader=layout_cfg["stream_label_leaders"],
+            leader_layer=leader_layer,
+        )
+        stream_id = stream.get("id")
+        if stream_id and stream_point:
+            stream_points[stream_id] = stream_point
     return stream_points
 
 

--- a/tests/test_pid_generation.py
+++ b/tests/test_pid_generation.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import ezdxf
+import pytest
 
 import programmatic_pid.generator as mod
+from programmatic_pid import sheet_rendering
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -129,3 +131,23 @@ def test_add_stream_draws_leader_line_when_displaced():
 
     leader_lines = [e for e in msp if e.dxftype() == "LINE" and e.dxf.layer == "LEADERS"]
     assert leader_lines, "Expected displaced label leader line on LEADERS layer"
+
+
+def test_process_stream_rendering_failures_propagate(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("stream routing failed")
+
+    monkeypatch.setattr(sheet_rendering, "add_stream", boom)
+
+    with pytest.raises(RuntimeError, match="stream routing failed"):
+        sheet_rendering._draw_process_streams(
+            ezdxf.new(setup=True).modelspace(),
+            minimal_spec(),
+            {"small_height": 1.2},
+            {"stream_label_scale": 0.8, "stream_label_leaders": False},
+            "TEXT",
+            "LEADERS",
+            {"E-1": {}, "E-2": {}},
+            1.0,
+            mod.LabelPlacer(),
+        )


### PR DESCRIPTION
## Summary
- Let process stream rendering errors propagate instead of logging and silently omitting streams.
- Adds regression coverage for the reported issue.

Closes #50

## Validation
- TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/test_pid_generation.py -q; python3 -m ruff check src/programmatic_pid/sheet_rendering.py tests/test_pid_generation.py; python3 -m black --check src/programmatic_pid/sheet_rendering.py tests/test_pid_generation.py
