### PR TITLE
[codex] Disable xvfb plugin in CI test jobs

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install quality tools
-        run: pip install ruff==0.14.10 black==25.12.0 mypy==1.13.0 bandit==1.7.7
+        run: pip install --force-reinstall ruff==0.14.10 black==25.12.0 mypy==1.13.0 bandit==1.7.7
 
       - name: Check tool version consistency
         shell: bash
@@ -70,9 +70,9 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -92,9 +92,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -104,7 +104,7 @@ jobs:
           pip install -e .
 
       - name: Run tests
-        run: pytest tests/ -v --cov=programmatic_pid --cov-report=xml --cov-report=term-missing
+        run: python -m pytest -p no:xvfb tests/ -v --cov=programmatic_pid --cov-report=xml --cov-report=term-missing
 
       - uses: codecov/codecov-action@v5
         if: ${{ env.CODECOV_TOKEN != '' }}

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -86,6 +86,8 @@ jobs:
     needs: quality-gate
     runs-on: self-hosted
     timeout-minutes: 20
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -105,7 +107,7 @@ jobs:
         run: pytest tests/ -v --cov=programmatic_pid --cov-report=xml --cov-report=term-missing
 
       - uses: codecov/codecov-action@v5
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Disables the auto-loaded pytest-xvfb plugin in CI test jobs so tests can run on the self-hosted runner without Xvfb startup timeouts.

Closes #56

## Validation
- Previous #55 quality-gate and security-scan jobs created and passed after workflow validation was fixed.
- This patch targets the observed test-job failure: `pyvirtualdisplay.abstractdisplay.XStartTimeoutError`.
