### PR TITLE
refactor: split dxf_builder.py into focused sub-modules

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,7 @@
 # Programmatic-PID Specification
 
+**Version:** 0.1.1 — 2026-04-16
+
 ## Purpose
 
 `Programmatic-PID` is a Python package for generating editable P&ID drawings from YAML specifications. It produces DXF output and optional SVG previews for review and drafting workflows.
@@ -23,7 +25,13 @@
 
 - `validator.py` validates YAML spec structure and raises `SpecValidationError` for invalid inputs.
 - `generator.py` loads specs, applies profiles, and keeps the public orchestration facade for sheet generation.
-- `dxf_builder.py` provides drawing primitives, geometry helpers, and layer utilities.
+- `dxf_builder.py` is the public facade for all DXF drawing helpers; it re-exports every name from the sub-modules below and also owns the high-level `add_equipment` and `add_instrument` renderers.
+- `dxf_math.py` provides numeric helpers (`to_float`, `clamp`) and bounding-box geometry (`text_box`, `rects_overlap`, `closest_point_on_rect`, `dedupe_points`).
+- `dxf_text.py` provides text utilities (`parse_alignment`, `wrap_text_lines`, `LabelPlacer`) and text-drawing primitives (`add_text`, `add_text_panel`).
+- `dxf_layer.py` provides layer management (`ensure_layer`, `ensure_layers`, `layer_name`).
+- `dxf_symbols.py` provides equipment shape primitives (`add_box`, `add_hopper`, `add_fan_symbol`, `add_rotary_valve_symbol`, `add_burner_symbol`, `add_bin_symbol`, `draw_equipment_symbol`).
+- `dxf_geometry.py` provides equipment geometry helpers and endpoint resolution (`equipment_dims`, `equipment_center`, `equipment_side_anchors`, `equipment_anchor`, `nearest_equipment_anchor`, `get_equipment_bounds`, `resolve_endpoint`, `spread_instrument_positions`).
+- `dxf_arrows.py` provides arrow drawing primitives (`add_arrow_head`, `add_arrow`, `add_poly_arrow`).
 - `stream_router.py` routes process streams between equipment anchors and handles labeling.
 - `control_loops.py` draws control-loop relationships and reference routing.
 - `notes.py` renders notes, mass balance values, and sheet annotations.
@@ -60,6 +68,6 @@ The package also supports layout profiles such as `review`, `presentation`, and 
 ## Maintenance Notes
 
 - Backward-compatible imports from `programmatic_pid.generator` are part of the current contract.
+- All public names from the `dxf_*` sub-modules are re-exported by `dxf_builder.py`; callers should continue to import from `programmatic_pid.dxf_builder`.
 - Documentation should remain consistent with the real package layout and public CLI behavior.
 - If a future change moves responsibility between modules, update this spec in the same change.
-

--- a/src/programmatic_pid/dxf_arrows.py
+++ b/src/programmatic_pid/dxf_arrows.py
@@ -1,0 +1,77 @@
+"""DXF arrow drawing primitives."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+from programmatic_pid.dxf_math import to_float
+
+
+def add_arrow_head(
+    msp: Any,
+    s: Sequence[float],
+    e: Sequence[float],
+    layer: str,
+    color: int | None = None,
+    arrow_size: float = 1.6,
+) -> None:
+    """Draw an arrowhead solid at the end of a line segment."""
+    sx, sy = to_float(s[0]), to_float(s[1])
+    ex, ey = to_float(e[0]), to_float(e[1])
+    attrs: dict[str, Any] = {"layer": layer}
+    if color is not None:
+        attrs["color"] = int(color)
+
+    ang = math.atan2(ey - sy, ex - sx)
+    ah = max(to_float(arrow_size, 1.6), 0.2)
+    aw = ah * 0.45
+    p1 = (ex, ey)
+    p2 = (
+        ex - ah * math.cos(ang) + aw * math.sin(ang),
+        ey - ah * math.sin(ang) - aw * math.cos(ang),
+    )
+    p3 = (
+        ex - ah * math.cos(ang) - aw * math.sin(ang),
+        ey - ah * math.sin(ang) + aw * math.cos(ang),
+    )
+    msp.add_solid([p1, p2, p3, p3], dxfattribs=attrs)
+
+
+def add_arrow(
+    msp: Any,
+    s: Sequence[float],
+    e: Sequence[float],
+    layer: str,
+    color: int | None = None,
+    arrow_size: float = 1.6,
+) -> None:
+    """Draw a line with an arrowhead at the end."""
+    sx, sy = to_float(s[0]), to_float(s[1])
+    ex, ey = to_float(e[0]), to_float(e[1])
+    attrs: dict[str, Any] = {"layer": layer}
+    if color is not None:
+        attrs["color"] = int(color)
+
+    msp.add_line((sx, sy), (ex, ey), dxfattribs=attrs)
+    add_arrow_head(msp, (sx, sy), (ex, ey), layer=layer, color=color, arrow_size=arrow_size)
+
+
+def add_poly_arrow(
+    msp: Any,
+    verts: list[Sequence[float]],
+    layer: str,
+    color: int | None = None,
+    arrow_size: float = 1.6,
+) -> None:
+    """Draw a polyline with an arrowhead at the last vertex."""
+    points = [(to_float(v[0]), to_float(v[1])) for v in verts if len(v) >= 2]
+    if len(points) < 2:
+        return
+
+    attrs: dict[str, Any] = {"layer": layer}
+    if color is not None:
+        attrs["color"] = int(color)
+    msp.add_lwpolyline(points, dxfattribs=attrs)
+    add_arrow_head(msp, points[-2], points[-1], layer, color=color, arrow_size=arrow_size)

--- a/src/programmatic_pid/dxf_builder.py
+++ b/src/programmatic_pid/dxf_builder.py
@@ -1,566 +1,109 @@
-"""Low-level DXF creation primitives: shapes, text, arrows, layers."""
+"""Low-level DXF creation primitives: shapes, text, arrows, layers.
+
+This module is the public interface for DXF drawing helpers.  The implementation
+has been split into focused sub-modules for maintainability:
+
+- :mod:`dxf_math`     – numeric helpers and bounding-box geometry
+- :mod:`dxf_text`     – text utilities and label placement
+- :mod:`dxf_layer`    – layer management
+- :mod:`dxf_symbols`  – equipment shape primitives
+- :mod:`dxf_geometry` – equipment geometry and endpoint resolution
+- :mod:`dxf_arrows`   – arrow drawing primitives
+
+All public names are re-exported here so existing imports remain unchanged.
+"""
 
 from __future__ import annotations
 
 import logging
-import math
-import textwrap
-from collections.abc import Sequence
 from typing import Any
 
-import ezdxf
-from ezdxf.enums import TextEntityAlignment
+from programmatic_pid.dxf_arrows import add_arrow, add_arrow_head, add_poly_arrow
+from programmatic_pid.dxf_geometry import (
+    equipment_anchor,
+    equipment_center,
+    equipment_dims,
+    equipment_side_anchors,
+    get_equipment_bounds,
+    nearest_equipment_anchor,
+    resolve_endpoint,
+    spread_instrument_positions,
+)
+from programmatic_pid.dxf_layer import ensure_layer, ensure_layers, layer_name
+from programmatic_pid.dxf_math import (
+    clamp,
+    closest_point_on_rect,
+    dedupe_points,
+    rects_overlap,
+    text_box,
+    to_float,
+)
+from programmatic_pid.dxf_symbols import (
+    add_bin_symbol,
+    add_box,
+    add_burner_symbol,
+    add_fan_symbol,
+    add_hopper,
+    add_rotary_valve_symbol,
+    draw_equipment_symbol,
+)
+from programmatic_pid.dxf_text import (
+    LabelPlacer,
+    add_text,
+    add_text_panel,
+    parse_alignment,
+    wrap_text_lines,
+)
 
 logger = logging.getLogger(__name__)
 
-
 # ---------------------------------------------------------------------------
-# Numeric helpers
-# ---------------------------------------------------------------------------
-
-
-def to_float(value: Any, default: float = 0.0) -> float:
-    """Convert *value* to float, returning *default* on failure."""
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return float(default)
-
-
-def clamp(value: float, lo: float, hi: float) -> float:
-    """Clamp *value* between *lo* and *hi*."""
-    return max(lo, min(hi, value))
-
-
-# ---------------------------------------------------------------------------
-# Text utilities
+# Re-export everything for backward compatibility
 # ---------------------------------------------------------------------------
 
-
-def parse_alignment(align: Any) -> TextEntityAlignment:
-    """Return a :class:`TextEntityAlignment` from a string or pass-through."""
-    if isinstance(align, TextEntityAlignment):
-        return align
-    key = str(align or "MIDDLE_CENTER").upper()
-    return getattr(TextEntityAlignment, key, TextEntityAlignment.MIDDLE_CENTER)
-
-
-def wrap_text_lines(text: str, width: int) -> list[str]:
-    """Word-wrap *text* to *width* characters."""
-    if not isinstance(text, str):
-        text = str(text)
-    if not isinstance(width, int) or width < 12:
-        width = 12
-    chunks = textwrap.wrap(
-        text,
-        width=max(int(width), 12),
-        break_long_words=False,
-        break_on_hyphens=False,
-    )
-    return chunks if chunks else [text]
-
-
-# ---------------------------------------------------------------------------
-# Bounding-box helpers
-# ---------------------------------------------------------------------------
-
-
-def text_box(
-    text: str, x: float, y: float, h: float, align: str = "MIDDLE_CENTER"
-) -> tuple[float, float, float, float]:
-    """Return an approximate bounding rectangle ``(x1, y1, x2, y2)`` for placed text."""
-    text = str(text)
-    h = max(to_float(h, 1.0), 0.1)
-    width = max(len(text), 1) * h * 0.55
-    height = h * 1.2
-    align = str(align or "MIDDLE_CENTER").upper()
-    if "LEFT" in align:
-        x1, x2 = x, x + width
-    elif "RIGHT" in align:
-        x1, x2 = x - width, x
-    else:
-        x1, x2 = x - width / 2, x + width / 2
-
-    if "TOP" in align:
-        y1, y2 = y - height, y
-    elif "BOTTOM" in align:
-        y1, y2 = y, y + height
-    else:
-        y1, y2 = y - height / 2, y + height / 2
-    return (x1, y1, x2, y2)
-
-
-def rects_overlap(
-    a: tuple[float, float, float, float],
-    b: tuple[float, float, float, float],
-    pad: float = 0.0,
-) -> bool:
-    """Return ``True`` if rectangles *a* and *b* overlap (with optional padding)."""
-    ax1, ay1, ax2, ay2 = a
-    bx1, by1, bx2, by2 = b
-    return not (ax2 + pad <= bx1 or bx2 + pad <= ax1 or ay2 + pad <= by1 or by2 + pad <= ay1)
-
-
-def closest_point_on_rect(
-    point: Sequence[float], rect: tuple[float, float, float, float]
-) -> tuple[float, float]:
-    """Return the closest point on *rect* to *point*."""
-    px, py = to_float(point[0]), to_float(point[1])
-    x1, y1, x2, y2 = rect
-    return clamp(px, x1, x2), clamp(py, y1, y2)
-
-
-# ---------------------------------------------------------------------------
-# Label collision avoidance
-# ---------------------------------------------------------------------------
-
-
-class LabelPlacer:
-    """Tracks occupied rectangles and finds non-overlapping label positions."""
-
-    def __init__(self) -> None:
-        self.occupied: list[tuple[float, float, float, float]] = []
-
-    def reserve_rect(self, rect: tuple[float, float, float, float]) -> None:
-        """Register *rect* as occupied space."""
-        self.occupied.append(rect)
-
-    def reserve_text(self, text: str, x: float, y: float, h: float, align: str = "MIDDLE_CENTER") -> None:
-        """Reserve the bounding box of a text label."""
-        self.reserve_rect(text_box(text, x, y, h, align=align))
-
-    def find_position(
-        self,
-        text: str,
-        anchor: tuple[float, float],
-        h: float,
-        preferred: list[tuple[float, float, str]],
-    ) -> tuple[float, float, str]:
-        """Find the first non-overlapping position from *preferred* offsets."""
-        ax, ay = to_float(anchor[0]), to_float(anchor[1])
-        for dx, dy, align in preferred:
-            x = ax + dx
-            y = ay + dy
-            candidate = text_box(text, x, y, h, align=align)
-            if not any(rects_overlap(candidate, r, pad=h * 0.20) for r in self.occupied):
-                self.reserve_rect(candidate)
-                return x, y, align
-        fallback = preferred[0]
-        x = ax + fallback[0]
-        y = ay + fallback[1]
-        align = fallback[2]
-        self.reserve_rect(text_box(text, x, y, h, align=align))
-        return x, y, align
-
-
-# ---------------------------------------------------------------------------
-# Layer helpers
-# ---------------------------------------------------------------------------
-
-
-def ensure_layer(doc: Any, name: str, color: int = 7, linetype: str = "CONTINUOUS") -> None:
-    """Create a DXF layer if it does not already exist."""
-    if not name:
-        return
-    if name in doc.layers:
-        return
-    attrs = {"color": int(color), "linetype": str(linetype)}
-    try:
-        doc.layers.new(name=name, dxfattribs=attrs)
-    except ezdxf.DXFValueError:
-        attrs["linetype"] = "CONTINUOUS"
-        doc.layers.new(name=name, dxfattribs=attrs)
-
-
-def ensure_layers(doc: Any, spec: dict[str, Any]) -> None:
-    """Create all layers referenced in *spec* plus sensible defaults."""
-    from programmatic_pid.generator import get_layer_config
-
-    for name, cfg in get_layer_config(spec).items():
-        cfg = cfg or {}
-        ensure_layer(doc, name, color=cfg.get("color", 7), linetype=cfg.get("linetype", "CONTINUOUS"))
-
-    for name, color in (
-        ("TEXT", 7),
-        ("NOTES", 3),
-        ("LEADERS", 8),
-        ("EQUIPMENT", 7),
-        ("INSTRUMENTS", 2),
-        ("PROCESS", 5),
-    ):
-        ltype = "DASHED" if name == "LEADERS" else "CONTINUOUS"
-        ensure_layer(doc, name, color=color, linetype=ltype)
-
-
-def layer_name(layer_index: dict[str, str], *candidates: str, default: str = "0") -> str:
-    """Resolve the first matching layer name from *candidates*."""
-    for candidate in candidates:
-        if not candidate:
-            continue
-        actual = layer_index.get(str(candidate).lower())
-        if actual:
-            return actual
-    return default
-
-
-# ---------------------------------------------------------------------------
-# DXF drawing primitives
-# ---------------------------------------------------------------------------
-
-
-def add_text(
-    msp: Any,
-    text: str,
-    x: float,
-    y: float,
-    h: float,
-    layer: str = "TEXT",
-    align: str = "MIDDLE_CENTER",
-) -> Any:
-    """Add a text entity to *msp*."""
-    t = msp.add_text(str(text), dxfattribs={"height": max(to_float(h, 1.0), 0.1), "layer": layer})
-    t.set_placement((to_float(x), to_float(y)), align=parse_alignment(align))
-    return t
-
-
-def add_text_panel(
-    msp: Any,
-    x: float,
-    y: float,
-    w: float,
-    h: float,
-    title: str,
-    lines: list[str],
-    text_h: float,
-    text_layer: str,
-    border_layer: str,
-    max_chars: int = 42,
-) -> None:
-    """Draw a bordered text panel with a title and wrapped body lines."""
-    add_box(msp, x, y, w, h, border_layer)
-    inset_x = x + 1.1
-    inset_top = y + h - 1.0
-    add_text(msp, title, inset_x, inset_top, text_h * 1.05, layer=text_layer, align="TOP_LEFT")
-
-    step = max(text_h * 1.16, 0.9)
-    available = max(int((h - 2.6) / step), 1)
-    out: list[str] = []
-    for line in lines:
-        if line is None:
-            out.append("")
-            continue
-        out.extend(wrap_text_lines(line, max_chars))
-    out = out[:available]
-
-    cy = inset_top - max(text_h * 1.55, 1.1)
-    for line in out:
-        add_text(msp, line, inset_x, cy, text_h, layer=text_layer, align="TOP_LEFT")
-        cy -= step
-
-
-def add_box(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
-    """Draw a rectangular polyline on *layer*."""
-    if w <= 0 or h <= 0:
-        raise ValueError(f"Box dimensions must be positive, got w={w}, h={h}")
-    x = to_float(x)
-    y = to_float(y)
-    w = to_float(w)
-    h = to_float(h)
-    pts = [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
-    msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": layer})
-
-
-def add_hopper(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
-    """Draw a hopper (tapered trapezoid) symbol."""
-    x = to_float(x)
-    y = to_float(y)
-    w = to_float(w)
-    h = to_float(h)
-    bot_w = w * 0.72
-    cx = x + w / 2
-    pts = [(x, y + h), (x + w, y + h), (cx + bot_w / 2, y), (cx - bot_w / 2, y)]
-    msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": layer})
-
-
-def add_fan_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
-    """Draw a fan symbol (circle + blade)."""
-    cx = x + w / 2
-    cy = y + h / 2
-    r = max(min(w, h) * 0.42, 0.5)
-    msp.add_circle((cx, cy), radius=r, dxfattribs={"layer": layer})
-    blade = [(cx - r * 0.25, cy), (cx + r * 0.45, cy + r * 0.20), (cx + r * 0.45, cy - r * 0.20)]
-    msp.add_lwpolyline(blade, close=True, dxfattribs={"layer": layer})
-
-
-def add_rotary_valve_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
-    """Draw a rotary valve symbol."""
-    cx = x + w / 2
-    cy = y + h / 2
-    r = max(min(w, h) * 0.35, 0.5)
-    msp.add_circle((cx, cy), radius=r, dxfattribs={"layer": layer})
-    msp.add_line((cx - r * 0.85, cy - r * 0.85), (cx + r * 0.85, cy + r * 0.85), dxfattribs={"layer": layer})
-    msp.add_line((cx - r * 0.85, cy + r * 0.85), (cx + r * 0.85, cy - r * 0.85), dxfattribs={"layer": layer})
-
-
-def add_burner_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
-    """Draw a burner symbol (box + flame)."""
-    add_box(msp, x, y, w, h, layer)
-    cx = x + w / 2
-    flame = [
-        (cx, y + h * 0.76),
-        (cx + w * 0.10, y + h * 0.48),
-        (cx, y + h * 0.22),
-        (cx - w * 0.10, y + h * 0.48),
-    ]
-    msp.add_lwpolyline(flame, close=True, dxfattribs={"layer": layer})
-
-
-def add_bin_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
-    """Draw a bin/silo symbol."""
-    add_box(msp, x, y, w, h, layer)
-    msp.add_line((x, y + h), (x + w, y + h), dxfattribs={"layer": layer})
-    msp.add_line(
-        (x + w * 0.1, y + h + h * 0.12), (x + w * 0.9, y + h + h * 0.12), dxfattribs={"layer": layer}
-    )
-
-
-def draw_equipment_symbol(msp: Any, eq: dict[str, Any], layer: str) -> None:
-    """Dispatch to the appropriate equipment shape renderer."""
-    x = to_float(eq.get("x", 0.0))
-    y = to_float(eq.get("y", 0.0))
-    w, h = equipment_dims(eq)
-    eq_type = str(eq.get("type", "")).lower()
-    subtype = str(eq.get("subtype", "")).lower()
-
-    if eq_type == "hopper":
-        add_hopper(msp, x, y, w, h, layer)
-        return
-    if eq_type == "fan":
-        add_fan_symbol(msp, x, y, w, h, layer)
-        return
-    if eq_type == "rotary_valve":
-        add_rotary_valve_symbol(msp, x, y, w, h, layer)
-        return
-    if eq_type == "burner":
-        add_burner_symbol(msp, x, y, w, h, layer)
-        return
-    if eq_type == "bin":
-        add_bin_symbol(msp, x, y, w, h, layer)
-        return
-
-    add_box(msp, x, y, w, h, layer)
-
-    if eq_type == "vertical_retort" or subtype == "vertical_retort":
-        for zone in eq.get("zones", []):
-            zy = y + h * to_float(zone.get("y_frac", 0.0))
-            msp.add_line((x + 0.6, zy), (x + w - 0.6, zy), dxfattribs={"layer": layer})
-
-
-def add_arrow_head(
-    msp: Any,
-    s: Sequence[float],
-    e: Sequence[float],
-    layer: str,
-    color: int | None = None,
-    arrow_size: float = 1.6,
-) -> None:
-    """Draw an arrowhead solid at the end of a line segment."""
-    sx, sy = to_float(s[0]), to_float(s[1])
-    ex, ey = to_float(e[0]), to_float(e[1])
-    attrs: dict[str, Any] = {"layer": layer}
-    if color is not None:
-        attrs["color"] = int(color)
-
-    ang = math.atan2(ey - sy, ex - sx)
-    ah = max(to_float(arrow_size, 1.6), 0.2)
-    aw = ah * 0.45
-    p1 = (ex, ey)
-    p2 = (
-        ex - ah * math.cos(ang) + aw * math.sin(ang),
-        ey - ah * math.sin(ang) - aw * math.cos(ang),
-    )
-    p3 = (
-        ex - ah * math.cos(ang) - aw * math.sin(ang),
-        ey - ah * math.sin(ang) + aw * math.cos(ang),
-    )
-    msp.add_solid([p1, p2, p3, p3], dxfattribs=attrs)
-
-
-def add_arrow(
-    msp: Any,
-    s: Sequence[float],
-    e: Sequence[float],
-    layer: str,
-    color: int | None = None,
-    arrow_size: float = 1.6,
-) -> None:
-    """Draw a line with an arrowhead at the end."""
-    sx, sy = to_float(s[0]), to_float(s[1])
-    ex, ey = to_float(e[0]), to_float(e[1])
-    attrs: dict[str, Any] = {"layer": layer}
-    if color is not None:
-        attrs["color"] = int(color)
-
-    msp.add_line((sx, sy), (ex, ey), dxfattribs=attrs)
-    add_arrow_head(msp, (sx, sy), (ex, ey), layer=layer, color=color, arrow_size=arrow_size)
-
-
-def add_poly_arrow(
-    msp: Any,
-    verts: list[Sequence[float]],
-    layer: str,
-    color: int | None = None,
-    arrow_size: float = 1.6,
-) -> None:
-    """Draw a polyline with an arrowhead at the last vertex."""
-    points = [(to_float(v[0]), to_float(v[1])) for v in verts if len(v) >= 2]
-    if len(points) < 2:
-        return
-
-    attrs: dict[str, Any] = {"layer": layer}
-    if color is not None:
-        attrs["color"] = int(color)
-    msp.add_lwpolyline(points, dxfattribs=attrs)
-    add_arrow_head(msp, points[-2], points[-1], layer, color=color, arrow_size=arrow_size)
-
-
-# ---------------------------------------------------------------------------
-# Equipment geometry helpers
-# ---------------------------------------------------------------------------
-
-
-def equipment_dims(eq: dict[str, Any]) -> tuple[float, float]:
-    """Return ``(width, height)`` of an equipment entry."""
-    return to_float(eq.get("w", eq.get("width", 0.0))), to_float(eq.get("h", eq.get("height", 0.0)))
-
-
-def equipment_center(eq: dict[str, Any]) -> tuple[float, float]:
-    """Return the centre point of an equipment item."""
-    x = to_float(eq.get("x", 0.0))
-    y = to_float(eq.get("y", 0.0))
-    w, h = equipment_dims(eq)
-    return x + w / 2, y + h / 2
-
-
-def equipment_side_anchors(eq: dict[str, Any]) -> dict[str, tuple[float, float]]:
-    """Return named side-anchor points for an equipment item."""
-    x = to_float(eq.get("x", 0.0))
-    y = to_float(eq.get("y", 0.0))
-    w, h = equipment_dims(eq)
-    return {
-        "left": (x, y + h / 2),
-        "right": (x + w, y + h / 2),
-        "top": (x + w / 2, y + h),
-        "bottom": (x + w / 2, y),
-    }
-
-
-def equipment_anchor(eq: dict[str, Any], side: str | None, offset: float = 0.0) -> tuple[float, float]:
-    """Return the anchor point for a given side of an equipment item."""
-    x = to_float(eq.get("x", 0.0))
-    y = to_float(eq.get("y", 0.0))
-    w, h = equipment_dims(eq)
-    side = str(side or "right").lower()
-    offset = to_float(offset, 0.0)
-
-    if side == "left":
-        return x, y + h / 2 + offset
-    if side == "top":
-        return x + w / 2 + offset, y + h
-    if side == "bottom":
-        return x + w / 2 + offset, y
-    return x + w, y + h / 2 + offset
-
-
-def nearest_equipment_anchor(eq: dict[str, Any], source: Sequence[float]) -> tuple[float, float]:
-    """Return the closest side-anchor on *eq* to *source*."""
-    sx, sy = to_float(source[0]), to_float(source[1])
-    anchors = equipment_side_anchors(eq).values()
-    return min(anchors, key=lambda p: (p[0] - sx) ** 2 + (p[1] - sy) ** 2)
-
-
-def get_equipment_bounds(spec: dict[str, Any]) -> tuple[float, float, float, float]:
-    """Return ``(x_min, y_min, x_max, y_max)`` bounding box of all equipment."""
-    equipment = spec.get("equipment", [])
-    if not equipment:
-        return 0.0, 0.0, 240.0, 160.0
-    x_min = min(to_float(eq.get("x", 0.0)) for eq in equipment)
-    y_min = min(to_float(eq.get("y", 0.0)) for eq in equipment)
-    x_max = max(to_float(eq.get("x", 0.0)) + equipment_dims(eq)[0] for eq in equipment)
-    y_max = max(to_float(eq.get("y", 0.0)) + equipment_dims(eq)[1] for eq in equipment)
-    return x_min, y_min, x_max, y_max
-
-
-def resolve_endpoint(endpoint: dict[str, Any] | None, equipment_by_id: dict[str, Any]) -> tuple[float, float]:
-    """Resolve a stream endpoint to ``(x, y)`` coordinates."""
-    endpoint = endpoint or {}
-    if "point" in endpoint:
-        px, py = endpoint["point"]
-        return to_float(px), to_float(py)
-
-    eq_id = endpoint.get("equipment")
-    if not eq_id or eq_id not in equipment_by_id:
-        raise KeyError(f"Unknown equipment endpoint: {eq_id}")
-    return equipment_anchor(
-        equipment_by_id[eq_id],
-        endpoint.get("side", "right"),
-        endpoint.get("offset", 0.0),
-    )
-
-
-def dedupe_points(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
-    """Remove consecutive duplicate points."""
-    cleaned: list[tuple[float, float]] = []
-    for p in points:
-        if not cleaned:
-            cleaned.append((to_float(p[0]), to_float(p[1])))
-            continue
-        px, py = cleaned[-1]
-        qx, qy = to_float(p[0]), to_float(p[1])
-        if abs(px - qx) < 1e-9 and abs(py - qy) < 1e-9:
-            continue
-        cleaned.append((qx, qy))
-    return cleaned
-
-
-def spread_instrument_positions(
-    instruments: list[dict[str, Any]], min_spacing: float = 3.5
-) -> list[dict[str, Any]]:
-    """Nudge overlapping instruments apart so they don't collide."""
-    placed: list[tuple[float, float]] = []
-    output: list[dict[str, Any]] = []
-    ring = [
-        (0.0, 0.0),
-        (2.0, 0.0),
-        (-2.0, 0.0),
-        (0.0, 2.0),
-        (0.0, -2.0),
-        (2.0, 2.0),
-        (-2.0, 2.0),
-        (2.0, -2.0),
-        (-2.0, -2.0),
-    ]
-    spacing = max(to_float(min_spacing, 3.5), 1.2)
-    for ins in instruments:
-        base_x = to_float(ins.get("x", 0.0))
-        base_y = to_float(ins.get("y", 0.0))
-        chosen = (base_x, base_y)
-        for radius in (1.0, 1.8, 2.6, 3.6):
-            found = None
-            for ox, oy in ring:
-                cand = (base_x + ox * radius, base_y + oy * radius)
-                if all((cand[0] - px) ** 2 + (cand[1] - py) ** 2 >= spacing**2 for px, py in placed):
-                    found = cand
-                    break
-            if found is not None:
-                chosen = found
-                break
-        placed.append(chosen)
-        copy = dict(ins)
-        copy["x"] = chosen[0]
-        copy["y"] = chosen[1]
-        output.append(copy)
-    return output
+__all__ = [
+    # dxf_math
+    "to_float",
+    "clamp",
+    "text_box",
+    "rects_overlap",
+    "closest_point_on_rect",
+    # dxf_text
+    "parse_alignment",
+    "wrap_text_lines",
+    "LabelPlacer",
+    "add_text",
+    "add_text_panel",
+    # dxf_layer
+    "ensure_layer",
+    "ensure_layers",
+    "layer_name",
+    # dxf_symbols
+    "add_box",
+    "add_hopper",
+    "add_fan_symbol",
+    "add_rotary_valve_symbol",
+    "add_burner_symbol",
+    "add_bin_symbol",
+    "draw_equipment_symbol",
+    # dxf_arrows
+    "add_arrow_head",
+    "add_arrow",
+    "add_poly_arrow",
+    # dxf_geometry
+    "equipment_dims",
+    "equipment_center",
+    "equipment_side_anchors",
+    "equipment_anchor",
+    "nearest_equipment_anchor",
+    "get_equipment_bounds",
+    "resolve_endpoint",
+    "dedupe_points",
+    "spread_instrument_positions",
+    # high-level renderers (defined below)
+    "add_equipment",
+    "add_instrument",
+]
 
 
 # ---------------------------------------------------------------------------

--- a/src/programmatic_pid/dxf_geometry.py
+++ b/src/programmatic_pid/dxf_geometry.py
@@ -1,0 +1,127 @@
+"""Equipment geometry helpers: anchors, bounds, endpoints, and instrument layout."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from programmatic_pid.dxf_math import to_float
+
+
+def equipment_dims(eq: dict[str, Any]) -> tuple[float, float]:
+    """Return ``(width, height)`` of an equipment entry."""
+    return to_float(eq.get("w", eq.get("width", 0.0))), to_float(eq.get("h", eq.get("height", 0.0)))
+
+
+def equipment_center(eq: dict[str, Any]) -> tuple[float, float]:
+    """Return the centre point of an equipment item."""
+    x = to_float(eq.get("x", 0.0))
+    y = to_float(eq.get("y", 0.0))
+    w, h = equipment_dims(eq)
+    return x + w / 2, y + h / 2
+
+
+def equipment_side_anchors(eq: dict[str, Any]) -> dict[str, tuple[float, float]]:
+    """Return named side-anchor points for an equipment item."""
+    x = to_float(eq.get("x", 0.0))
+    y = to_float(eq.get("y", 0.0))
+    w, h = equipment_dims(eq)
+    return {
+        "left": (x, y + h / 2),
+        "right": (x + w, y + h / 2),
+        "top": (x + w / 2, y + h),
+        "bottom": (x + w / 2, y),
+    }
+
+
+def equipment_anchor(eq: dict[str, Any], side: str | None, offset: float = 0.0) -> tuple[float, float]:
+    """Return the anchor point for a given side of an equipment item."""
+    x = to_float(eq.get("x", 0.0))
+    y = to_float(eq.get("y", 0.0))
+    w, h = equipment_dims(eq)
+    side = str(side or "right").lower()
+    offset = to_float(offset, 0.0)
+
+    if side == "left":
+        return x, y + h / 2 + offset
+    if side == "top":
+        return x + w / 2 + offset, y + h
+    if side == "bottom":
+        return x + w / 2 + offset, y
+    return x + w, y + h / 2 + offset
+
+
+def nearest_equipment_anchor(eq: dict[str, Any], source: Sequence[float]) -> tuple[float, float]:
+    """Return the closest side-anchor on *eq* to *source*."""
+    sx, sy = to_float(source[0]), to_float(source[1])
+    anchors = equipment_side_anchors(eq).values()
+    return min(anchors, key=lambda p: (p[0] - sx) ** 2 + (p[1] - sy) ** 2)
+
+
+def get_equipment_bounds(spec: dict[str, Any]) -> tuple[float, float, float, float]:
+    """Return ``(x_min, y_min, x_max, y_max)`` bounding box of all equipment."""
+    equipment = spec.get("equipment", [])
+    if not equipment:
+        return 0.0, 0.0, 240.0, 160.0
+    x_min = min(to_float(eq.get("x", 0.0)) for eq in equipment)
+    y_min = min(to_float(eq.get("y", 0.0)) for eq in equipment)
+    x_max = max(to_float(eq.get("x", 0.0)) + equipment_dims(eq)[0] for eq in equipment)
+    y_max = max(to_float(eq.get("y", 0.0)) + equipment_dims(eq)[1] for eq in equipment)
+    return x_min, y_min, x_max, y_max
+
+
+def resolve_endpoint(endpoint: dict[str, Any] | None, equipment_by_id: dict[str, Any]) -> tuple[float, float]:
+    """Resolve a stream endpoint to ``(x, y)`` coordinates."""
+    endpoint = endpoint or {}
+    if "point" in endpoint:
+        px, py = endpoint["point"]
+        return to_float(px), to_float(py)
+
+    eq_id = endpoint.get("equipment")
+    if not eq_id or eq_id not in equipment_by_id:
+        raise KeyError(f"Unknown equipment endpoint: {eq_id}")
+    return equipment_anchor(
+        equipment_by_id[eq_id],
+        endpoint.get("side", "right"),
+        endpoint.get("offset", 0.0),
+    )
+
+
+def spread_instrument_positions(
+    instruments: list[dict[str, Any]], min_spacing: float = 3.5
+) -> list[dict[str, Any]]:
+    """Nudge overlapping instruments apart so they don't collide."""
+    placed: list[tuple[float, float]] = []
+    output: list[dict[str, Any]] = []
+    ring = [
+        (0.0, 0.0),
+        (2.0, 0.0),
+        (-2.0, 0.0),
+        (0.0, 2.0),
+        (0.0, -2.0),
+        (2.0, 2.0),
+        (-2.0, 2.0),
+        (2.0, -2.0),
+        (-2.0, -2.0),
+    ]
+    spacing = max(to_float(min_spacing, 3.5), 1.2)
+    for ins in instruments:
+        base_x = to_float(ins.get("x", 0.0))
+        base_y = to_float(ins.get("y", 0.0))
+        chosen = (base_x, base_y)
+        for radius in (1.0, 1.8, 2.6, 3.6):
+            found = None
+            for ox, oy in ring:
+                cand = (base_x + ox * radius, base_y + oy * radius)
+                if all((cand[0] - px) ** 2 + (cand[1] - py) ** 2 >= spacing**2 for px, py in placed):
+                    found = cand
+                    break
+            if found is not None:
+                chosen = found
+                break
+        placed.append(chosen)
+        copy = dict(ins)
+        copy["x"] = chosen[0]
+        copy["y"] = chosen[1]
+        output.append(copy)
+    return output

--- a/src/programmatic_pid/dxf_layer.py
+++ b/src/programmatic_pid/dxf_layer.py
@@ -1,0 +1,52 @@
+"""DXF layer management utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ezdxf
+
+
+def ensure_layer(doc: Any, name: str, color: int = 7, linetype: str = "CONTINUOUS") -> None:
+    """Create a DXF layer if it does not already exist."""
+    if not name:
+        return
+    if name in doc.layers:
+        return
+    attrs = {"color": int(color), "linetype": str(linetype)}
+    try:
+        doc.layers.new(name=name, dxfattribs=attrs)
+    except ezdxf.DXFValueError:
+        attrs["linetype"] = "CONTINUOUS"
+        doc.layers.new(name=name, dxfattribs=attrs)
+
+
+def ensure_layers(doc: Any, spec: dict[str, Any]) -> None:
+    """Create all layers referenced in *spec* plus sensible defaults."""
+    from programmatic_pid.generator import get_layer_config
+
+    for name, cfg in get_layer_config(spec).items():
+        cfg = cfg or {}
+        ensure_layer(doc, name, color=cfg.get("color", 7), linetype=cfg.get("linetype", "CONTINUOUS"))
+
+    for name, color in (
+        ("TEXT", 7),
+        ("NOTES", 3),
+        ("LEADERS", 8),
+        ("EQUIPMENT", 7),
+        ("INSTRUMENTS", 2),
+        ("PROCESS", 5),
+    ):
+        ltype = "DASHED" if name == "LEADERS" else "CONTINUOUS"
+        ensure_layer(doc, name, color=color, linetype=ltype)
+
+
+def layer_name(layer_index: dict[str, str], *candidates: str, default: str = "0") -> str:
+    """Resolve the first matching layer name from *candidates*."""
+    for candidate in candidates:
+        if not candidate:
+            continue
+        actual = layer_index.get(str(candidate).lower())
+        if actual:
+            return actual
+    return default

--- a/src/programmatic_pid/dxf_math.py
+++ b/src/programmatic_pid/dxf_math.py
@@ -1,0 +1,79 @@
+"""Numeric and geometric math helpers for DXF drawing."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def to_float(value: Any, default: float = 0.0) -> float:
+    """Convert *value* to float, returning *default* on failure."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp *value* between *lo* and *hi*."""
+    return max(lo, min(hi, value))
+
+
+def text_box(
+    text: str, x: float, y: float, h: float, align: str = "MIDDLE_CENTER"
+) -> tuple[float, float, float, float]:
+    """Return an approximate bounding rectangle ``(x1, y1, x2, y2)`` for placed text."""
+    text = str(text)
+    h = max(to_float(h, 1.0), 0.1)
+    width = max(len(text), 1) * h * 0.55
+    height = h * 1.2
+    align = str(align or "MIDDLE_CENTER").upper()
+    if "LEFT" in align:
+        x1, x2 = x, x + width
+    elif "RIGHT" in align:
+        x1, x2 = x - width, x
+    else:
+        x1, x2 = x - width / 2, x + width / 2
+
+    if "TOP" in align:
+        y1, y2 = y - height, y
+    elif "BOTTOM" in align:
+        y1, y2 = y, y + height
+    else:
+        y1, y2 = y - height / 2, y + height / 2
+    return (x1, y1, x2, y2)
+
+
+def rects_overlap(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+    pad: float = 0.0,
+) -> bool:
+    """Return ``True`` if rectangles *a* and *b* overlap (with optional padding)."""
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    return not (ax2 + pad <= bx1 or bx2 + pad <= ax1 or ay2 + pad <= by1 or by2 + pad <= ay1)
+
+
+def closest_point_on_rect(
+    point: Sequence[float], rect: tuple[float, float, float, float]
+) -> tuple[float, float]:
+    """Return the closest point on *rect* to *point*."""
+    px, py = to_float(point[0]), to_float(point[1])
+    x1, y1, x2, y2 = rect
+    return clamp(px, x1, x2), clamp(py, y1, y2)
+
+
+def dedupe_points(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Remove consecutive duplicate points."""
+    cleaned: list[tuple[float, float]] = []
+    for p in points:
+        if not cleaned:
+            cleaned.append((to_float(p[0]), to_float(p[1])))
+            continue
+        px, py = cleaned[-1]
+        qx, qy = to_float(p[0]), to_float(p[1])
+        if abs(px - qx) < 1e-9 and abs(py - qy) < 1e-9:
+            continue
+        cleaned.append((qx, qy))
+    return cleaned

--- a/src/programmatic_pid/dxf_symbols.py
+++ b/src/programmatic_pid/dxf_symbols.py
@@ -1,0 +1,107 @@
+"""DXF equipment shape symbols and drawing primitives."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from programmatic_pid.dxf_math import to_float
+
+
+def add_box(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
+    """Draw a rectangular polyline on *layer*."""
+    if w <= 0 or h <= 0:
+        raise ValueError(f"Box dimensions must be positive, got w={w}, h={h}")
+    x = to_float(x)
+    y = to_float(y)
+    w = to_float(w)
+    h = to_float(h)
+    pts = [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
+    msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": layer})
+
+
+def add_hopper(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
+    """Draw a hopper (tapered trapezoid) symbol."""
+    x = to_float(x)
+    y = to_float(y)
+    w = to_float(w)
+    h = to_float(h)
+    bot_w = w * 0.72
+    cx = x + w / 2
+    pts = [(x, y + h), (x + w, y + h), (cx + bot_w / 2, y), (cx - bot_w / 2, y)]
+    msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": layer})
+
+
+def add_fan_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
+    """Draw a fan symbol (circle + blade)."""
+    cx = x + w / 2
+    cy = y + h / 2
+    r = max(min(w, h) * 0.42, 0.5)
+    msp.add_circle((cx, cy), radius=r, dxfattribs={"layer": layer})
+    blade = [(cx - r * 0.25, cy), (cx + r * 0.45, cy + r * 0.20), (cx + r * 0.45, cy - r * 0.20)]
+    msp.add_lwpolyline(blade, close=True, dxfattribs={"layer": layer})
+
+
+def add_rotary_valve_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
+    """Draw a rotary valve symbol."""
+    cx = x + w / 2
+    cy = y + h / 2
+    r = max(min(w, h) * 0.35, 0.5)
+    msp.add_circle((cx, cy), radius=r, dxfattribs={"layer": layer})
+    msp.add_line((cx - r * 0.85, cy - r * 0.85), (cx + r * 0.85, cy + r * 0.85), dxfattribs={"layer": layer})
+    msp.add_line((cx - r * 0.85, cy + r * 0.85), (cx + r * 0.85, cy - r * 0.85), dxfattribs={"layer": layer})
+
+
+def add_burner_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
+    """Draw a burner symbol (box + flame)."""
+    add_box(msp, x, y, w, h, layer)
+    cx = x + w / 2
+    flame = [
+        (cx, y + h * 0.76),
+        (cx + w * 0.10, y + h * 0.48),
+        (cx, y + h * 0.22),
+        (cx - w * 0.10, y + h * 0.48),
+    ]
+    msp.add_lwpolyline(flame, close=True, dxfattribs={"layer": layer})
+
+
+def add_bin_symbol(msp: Any, x: float, y: float, w: float, h: float, layer: str) -> None:
+    """Draw a bin/silo symbol."""
+    add_box(msp, x, y, w, h, layer)
+    msp.add_line((x, y + h), (x + w, y + h), dxfattribs={"layer": layer})
+    msp.add_line(
+        (x + w * 0.1, y + h + h * 0.12), (x + w * 0.9, y + h + h * 0.12), dxfattribs={"layer": layer}
+    )
+
+
+def draw_equipment_symbol(msp: Any, eq: dict[str, Any], layer: str) -> None:
+    """Dispatch to the appropriate equipment shape renderer."""
+    from programmatic_pid.dxf_geometry import equipment_dims
+
+    x = to_float(eq.get("x", 0.0))
+    y = to_float(eq.get("y", 0.0))
+    w, h = equipment_dims(eq)
+    eq_type = str(eq.get("type", "")).lower()
+    subtype = str(eq.get("subtype", "")).lower()
+
+    if eq_type == "hopper":
+        add_hopper(msp, x, y, w, h, layer)
+        return
+    if eq_type == "fan":
+        add_fan_symbol(msp, x, y, w, h, layer)
+        return
+    if eq_type == "rotary_valve":
+        add_rotary_valve_symbol(msp, x, y, w, h, layer)
+        return
+    if eq_type == "burner":
+        add_burner_symbol(msp, x, y, w, h, layer)
+        return
+    if eq_type == "bin":
+        add_bin_symbol(msp, x, y, w, h, layer)
+        return
+
+    add_box(msp, x, y, w, h, layer)
+
+    if eq_type == "vertical_retort" or subtype == "vertical_retort":
+        for zone in eq.get("zones", []):
+            zy = y + h * to_float(zone.get("y_frac", 0.0))
+            msp.add_line((x + 0.6, zy), (x + w - 0.6, zy), dxfattribs={"layer": layer})

--- a/src/programmatic_pid/dxf_text.py
+++ b/src/programmatic_pid/dxf_text.py
@@ -1,0 +1,123 @@
+"""Text utilities and label placement for DXF drawings."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any
+
+from ezdxf.enums import TextEntityAlignment
+
+from programmatic_pid.dxf_math import rects_overlap, text_box, to_float
+
+
+def parse_alignment(align: Any) -> TextEntityAlignment:
+    """Return a :class:`TextEntityAlignment` from a string or pass-through."""
+    if isinstance(align, TextEntityAlignment):
+        return align
+    key = str(align or "MIDDLE_CENTER").upper()
+    return getattr(TextEntityAlignment, key, TextEntityAlignment.MIDDLE_CENTER)
+
+
+def wrap_text_lines(text: str, width: int) -> list[str]:
+    """Word-wrap *text* to *width* characters."""
+    if not isinstance(text, str):
+        text = str(text)
+    if not isinstance(width, int) or width < 12:
+        width = 12
+    chunks = textwrap.wrap(
+        text,
+        width=max(int(width), 12),
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+    return chunks if chunks else [text]
+
+
+class LabelPlacer:
+    """Tracks occupied rectangles and finds non-overlapping label positions."""
+
+    def __init__(self) -> None:
+        self.occupied: list[tuple[float, float, float, float]] = []
+
+    def reserve_rect(self, rect: tuple[float, float, float, float]) -> None:
+        """Register *rect* as occupied space."""
+        self.occupied.append(rect)
+
+    def reserve_text(self, text: str, x: float, y: float, h: float, align: str = "MIDDLE_CENTER") -> None:
+        """Reserve the bounding box of a text label."""
+        self.reserve_rect(text_box(text, x, y, h, align=align))
+
+    def find_position(
+        self,
+        text: str,
+        anchor: tuple[float, float],
+        h: float,
+        preferred: list[tuple[float, float, str]],
+    ) -> tuple[float, float, str]:
+        """Find the first non-overlapping position from *preferred* offsets."""
+        ax, ay = to_float(anchor[0]), to_float(anchor[1])
+        for dx, dy, align in preferred:
+            x = ax + dx
+            y = ay + dy
+            candidate = text_box(text, x, y, h, align=align)
+            if not any(rects_overlap(candidate, r, pad=h * 0.20) for r in self.occupied):
+                self.reserve_rect(candidate)
+                return x, y, align
+        fallback = preferred[0]
+        x = ax + fallback[0]
+        y = ay + fallback[1]
+        align = fallback[2]
+        self.reserve_rect(text_box(text, x, y, h, align=align))
+        return x, y, align
+
+
+def add_text(
+    msp: Any,
+    text: str,
+    x: float,
+    y: float,
+    h: float,
+    layer: str = "TEXT",
+    align: str = "MIDDLE_CENTER",
+) -> Any:
+    """Add a text entity to *msp*."""
+    t = msp.add_text(str(text), dxfattribs={"height": max(to_float(h, 1.0), 0.1), "layer": layer})
+    t.set_placement((to_float(x), to_float(y)), align=parse_alignment(align))
+    return t
+
+
+def add_text_panel(
+    msp: Any,
+    x: float,
+    y: float,
+    w: float,
+    h: float,
+    title: str,
+    lines: list[str],
+    text_h: float,
+    text_layer: str,
+    border_layer: str,
+    max_chars: int = 42,
+) -> None:
+    """Draw a bordered text panel with a title and wrapped body lines."""
+    from programmatic_pid.dxf_symbols import add_box
+
+    add_box(msp, x, y, w, h, border_layer)
+    inset_x = x + 1.1
+    inset_top = y + h - 1.0
+    add_text(msp, title, inset_x, inset_top, text_h * 1.05, layer=text_layer, align="TOP_LEFT")
+
+    step = max(text_h * 1.16, 0.9)
+    available = max(int((h - 2.6) / step), 1)
+    out: list[str] = []
+    for line in lines:
+        if line is None:
+            out.append("")
+            continue
+        out.extend(wrap_text_lines(line, max_chars))
+    out = out[:available]
+
+    cy = inset_top - max(text_h * 1.55, 1.1)
+    for line in out:
+        add_text(msp, line, inset_x, cy, text_h, layer=text_layer, align="TOP_LEFT")
+        cy -= step

--- a/tests/test_dxf_submodules.py
+++ b/tests/test_dxf_submodules.py
@@ -1,0 +1,429 @@
+"""Unit tests for extracted dxf_* sub-modules (issue #58).
+
+Each sub-module gets at least one new test that exercises it directly rather
+than going through the dxf_builder facade, verifying the split is clean.
+"""
+
+from __future__ import annotations
+
+import math
+
+import ezdxf
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def doc():
+    return ezdxf.new(setup=True)
+
+
+@pytest.fixture()
+def msp(doc):
+    return doc.modelspace()
+
+
+# ===========================================================================
+# dxf_math
+# ===========================================================================
+
+
+class TestDxfMathDirect:
+    """Import directly from dxf_math — not through dxf_builder."""
+
+    def test_to_float_string(self):
+        from programmatic_pid.dxf_math import to_float
+
+        assert to_float("2.5") == pytest.approx(2.5)
+
+    def test_to_float_bad_input(self):
+        from programmatic_pid.dxf_math import to_float
+
+        assert to_float("not-a-number", 7.0) == 7.0
+
+    def test_clamp_low(self):
+        from programmatic_pid.dxf_math import clamp
+
+        assert clamp(-10, 0, 5) == 0
+
+    def test_clamp_high(self):
+        from programmatic_pid.dxf_math import clamp
+
+        assert clamp(100, 0, 5) == 5
+
+    def test_text_box_dimensions_positive(self):
+        from programmatic_pid.dxf_math import text_box
+
+        x1, y1, x2, y2 = text_box("Hello", 0, 0, 2.0)
+        assert x2 > x1
+        assert y2 > y1
+
+    def test_rects_overlap_true(self):
+        from programmatic_pid.dxf_math import rects_overlap
+
+        assert rects_overlap((0, 0, 5, 5), (3, 3, 8, 8))
+
+    def test_rects_overlap_false(self):
+        from programmatic_pid.dxf_math import rects_overlap
+
+        assert not rects_overlap((0, 0, 2, 2), (5, 5, 9, 9))
+
+    def test_closest_point_outside(self):
+        from programmatic_pid.dxf_math import closest_point_on_rect
+
+        assert closest_point_on_rect((15, 5), (0, 0, 10, 10)) == (10.0, 5.0)
+
+    def test_dedupe_removes_dupes(self):
+        from programmatic_pid.dxf_math import dedupe_points
+
+        pts = [(1, 2), (1, 2), (3, 4)]
+        assert dedupe_points(pts) == [(1.0, 2.0), (3.0, 4.0)]
+
+    def test_dedupe_empty(self):
+        from programmatic_pid.dxf_math import dedupe_points
+
+        assert dedupe_points([]) == []
+
+
+# ===========================================================================
+# dxf_text
+# ===========================================================================
+
+
+class TestDxfTextDirect:
+    """Import directly from dxf_text."""
+
+    def test_parse_alignment_string(self):
+        from ezdxf.enums import TextEntityAlignment
+
+        from programmatic_pid.dxf_text import parse_alignment
+
+        assert parse_alignment("TOP_LEFT") == TextEntityAlignment.TOP_LEFT
+
+    def test_parse_alignment_none_defaults(self):
+        from ezdxf.enums import TextEntityAlignment
+
+        from programmatic_pid.dxf_text import parse_alignment
+
+        assert parse_alignment(None) == TextEntityAlignment.MIDDLE_CENTER
+
+    def test_wrap_text_lines_wraps(self):
+        from programmatic_pid.dxf_text import wrap_text_lines
+
+        lines = wrap_text_lines("the quick brown fox jumps over the lazy dog", 15)
+        assert len(lines) >= 2
+
+    def test_wrap_text_lines_short(self):
+        from programmatic_pid.dxf_text import wrap_text_lines
+
+        assert wrap_text_lines("hi", 80) == ["hi"]
+
+    def test_label_placer_reserve_and_check(self):
+        from programmatic_pid.dxf_text import LabelPlacer
+
+        placer = LabelPlacer()
+        placer.reserve_rect((0, 0, 5, 5))
+        assert len(placer.occupied) == 1
+
+    def test_label_placer_find_clear_position(self):
+        from programmatic_pid.dxf_text import LabelPlacer
+
+        placer = LabelPlacer()
+        placer.reserve_rect((0, 0, 5, 5))
+        preferred = [(0, 0, "MIDDLE_CENTER"), (20, 0, "MIDDLE_LEFT")]
+        x, y, align = placer.find_position("T", (2, 2), 1.0, preferred)
+        assert align == "MIDDLE_LEFT"
+
+    def test_add_text_entity_type(self, msp):
+        from programmatic_pid.dxf_text import add_text
+
+        t = add_text(msp, "Test", 0, 0, 2.0, layer="TEXT")
+        assert t.dxftype() == "TEXT"
+
+    def test_add_text_panel_creates_border(self, msp):
+        from programmatic_pid.dxf_text import add_text_panel
+
+        add_text_panel(msp, 0, 0, 40, 20, "Title", ["Body line"], 1.5, "TEXT", "BORDER")
+        polys = [e for e in msp if e.dxftype() == "LWPOLYLINE"]
+        assert len(polys) == 1
+
+
+# ===========================================================================
+# dxf_layer
+# ===========================================================================
+
+
+class TestDxfLayerDirect:
+    """Import directly from dxf_layer."""
+
+    def test_ensure_layer_creates(self, doc):
+        from programmatic_pid.dxf_layer import ensure_layer
+
+        ensure_layer(doc, "NEW_LAYER", color=4)
+        assert "NEW_LAYER" in doc.layers
+
+    def test_ensure_layer_idempotent(self, doc):
+        from programmatic_pid.dxf_layer import ensure_layer
+
+        ensure_layer(doc, "DUP", color=1)
+        ensure_layer(doc, "DUP", color=2)
+        assert "DUP" in doc.layers
+
+    def test_ensure_layer_empty_name_noop(self, doc):
+        from programmatic_pid.dxf_layer import ensure_layer
+
+        count_before = len(list(doc.layers))
+        ensure_layer(doc, "")
+        assert len(list(doc.layers)) == count_before
+
+    def test_ensure_layer_bad_linetype_fallback(self, doc):
+        from programmatic_pid.dxf_layer import ensure_layer
+
+        ensure_layer(doc, "BAD_LT", linetype="DOES_NOT_EXIST")
+        assert "BAD_LT" in doc.layers
+
+    def test_layer_name_resolves(self):
+        from programmatic_pid.dxf_layer import layer_name
+
+        idx = {"process": "PROCESS_LAYER"}
+        assert layer_name(idx, "process") == "PROCESS_LAYER"
+
+    def test_layer_name_default(self):
+        from programmatic_pid.dxf_layer import layer_name
+
+        assert layer_name({}, "missing") == "0"
+
+    def test_layer_name_skips_empty(self):
+        from programmatic_pid.dxf_layer import layer_name
+
+        idx = {"text": "TEXT_LAYER"}
+        assert layer_name(idx, "", None, "text") == "TEXT_LAYER"
+
+
+# ===========================================================================
+# dxf_symbols
+# ===========================================================================
+
+
+class TestDxfSymbolsDirect:
+    """Import directly from dxf_symbols."""
+
+    def test_add_box_creates_polyline(self, msp):
+        from programmatic_pid.dxf_symbols import add_box
+
+        add_box(msp, 0, 0, 10, 5, "0")
+        assert any(e.dxftype() == "LWPOLYLINE" for e in msp)
+
+    def test_add_box_negative_raises(self, msp):
+        from programmatic_pid.dxf_symbols import add_box
+
+        with pytest.raises(ValueError):
+            add_box(msp, 0, 0, -1, 5, "0")
+
+    def test_add_hopper_closed_poly(self, msp):
+        from programmatic_pid.dxf_symbols import add_hopper
+
+        add_hopper(msp, 0, 0, 10, 10, "0")
+        polys = [e for e in msp if e.dxftype() == "LWPOLYLINE"]
+        assert len(polys) == 1
+
+    def test_add_fan_symbol_has_circle(self, msp):
+        from programmatic_pid.dxf_symbols import add_fan_symbol
+
+        add_fan_symbol(msp, 0, 0, 10, 10, "0")
+        assert any(e.dxftype() == "CIRCLE" for e in msp)
+
+    def test_add_rotary_valve_cross_lines(self, msp):
+        from programmatic_pid.dxf_symbols import add_rotary_valve_symbol
+
+        add_rotary_valve_symbol(msp, 0, 0, 10, 10, "0")
+        lines = [e for e in msp if e.dxftype() == "LINE"]
+        assert len(lines) == 2
+
+    def test_add_burner_box_and_flame(self, msp):
+        from programmatic_pid.dxf_symbols import add_burner_symbol
+
+        add_burner_symbol(msp, 0, 0, 10, 10, "0")
+        polys = [e for e in msp if e.dxftype() == "LWPOLYLINE"]
+        assert len(polys) == 2
+
+    def test_add_bin_lines(self, msp):
+        from programmatic_pid.dxf_symbols import add_bin_symbol
+
+        add_bin_symbol(msp, 0, 0, 10, 10, "0")
+        lines = [e for e in msp if e.dxftype() == "LINE"]
+        assert len(lines) == 2
+
+    def test_draw_equipment_symbol_hopper(self, msp):
+        from programmatic_pid.dxf_symbols import draw_equipment_symbol
+
+        eq = {"type": "hopper", "x": 0, "y": 0, "w": 10, "h": 10}
+        draw_equipment_symbol(msp, eq, "0")
+        assert any(e.dxftype() == "LWPOLYLINE" for e in msp)
+
+    def test_draw_equipment_symbol_default_box(self, msp):
+        from programmatic_pid.dxf_symbols import draw_equipment_symbol
+
+        eq = {"type": "unknown", "x": 0, "y": 0, "w": 8, "h": 6}
+        draw_equipment_symbol(msp, eq, "0")
+        assert any(e.dxftype() == "LWPOLYLINE" for e in msp)
+
+    def test_draw_equipment_symbol_vertical_retort_zones(self, msp):
+        from programmatic_pid.dxf_symbols import draw_equipment_symbol
+
+        eq = {
+            "type": "vertical_retort",
+            "x": 0,
+            "y": 0,
+            "w": 10,
+            "h": 20,
+            "zones": [{"name": "Z1", "y_frac": 0.5}],
+        }
+        draw_equipment_symbol(msp, eq, "0")
+        lines = [e for e in msp if e.dxftype() == "LINE"]
+        assert len(lines) >= 1
+
+
+# ===========================================================================
+# dxf_geometry
+# ===========================================================================
+
+
+class TestDxfGeometryDirect:
+    """Import directly from dxf_geometry."""
+
+    def test_equipment_dims_wh(self):
+        from programmatic_pid.dxf_geometry import equipment_dims
+
+        assert equipment_dims({"w": 5, "h": 3}) == (5.0, 3.0)
+
+    def test_equipment_dims_width_height(self):
+        from programmatic_pid.dxf_geometry import equipment_dims
+
+        assert equipment_dims({"width": 8, "height": 4}) == (8.0, 4.0)
+
+    def test_equipment_center(self):
+        from programmatic_pid.dxf_geometry import equipment_center
+
+        eq = {"x": 0, "y": 0, "w": 10, "h": 6}
+        assert equipment_center(eq) == (5.0, 3.0)
+
+    def test_equipment_side_anchors_keys(self):
+        from programmatic_pid.dxf_geometry import equipment_side_anchors
+
+        eq = {"x": 0, "y": 0, "w": 10, "h": 10}
+        anchors = equipment_side_anchors(eq)
+        assert set(anchors) == {"left", "right", "top", "bottom"}
+
+    def test_equipment_anchor_left(self):
+        from programmatic_pid.dxf_geometry import equipment_anchor
+
+        eq = {"x": 0, "y": 0, "w": 10, "h": 10}
+        assert equipment_anchor(eq, "left") == (0.0, 5.0)
+
+    def test_equipment_anchor_bottom(self):
+        from programmatic_pid.dxf_geometry import equipment_anchor
+
+        eq = {"x": 0, "y": 0, "w": 10, "h": 10}
+        assert equipment_anchor(eq, "bottom") == (5.0, 0.0)
+
+    def test_nearest_equipment_anchor(self):
+        from programmatic_pid.dxf_geometry import nearest_equipment_anchor
+
+        eq = {"x": 0, "y": 0, "w": 10, "h": 10}
+        assert nearest_equipment_anchor(eq, (15, 5)) == (10.0, 5.0)
+
+    def test_get_equipment_bounds_with_items(self):
+        from programmatic_pid.dxf_geometry import get_equipment_bounds
+
+        spec = {"equipment": [{"x": 5, "y": 10, "w": 3, "h": 4}]}
+        x_min, y_min, x_max, y_max = get_equipment_bounds(spec)
+        assert x_min == 5.0
+        assert y_min == 10.0
+        assert x_max == 8.0
+        assert y_max == 14.0
+
+    def test_get_equipment_bounds_empty_defaults(self):
+        from programmatic_pid.dxf_geometry import get_equipment_bounds
+
+        assert get_equipment_bounds({}) == (0.0, 0.0, 240.0, 160.0)
+
+    def test_resolve_endpoint_point(self):
+        from programmatic_pid.dxf_geometry import resolve_endpoint
+
+        assert resolve_endpoint({"point": [3, 7]}, {}) == (3.0, 7.0)
+
+    def test_resolve_endpoint_equipment(self):
+        from programmatic_pid.dxf_geometry import resolve_endpoint
+
+        eq_map = {"V-1": {"x": 0, "y": 0, "w": 10, "h": 10}}
+        result = resolve_endpoint({"equipment": "V-1", "side": "right"}, eq_map)
+        assert result == (10.0, 5.0)
+
+    def test_resolve_endpoint_unknown_raises(self):
+        from programmatic_pid.dxf_geometry import resolve_endpoint
+
+        with pytest.raises(KeyError, match="Unknown equipment"):
+            resolve_endpoint({"equipment": "GHOST"}, {})
+
+    def test_spread_instrument_positions_separates(self):
+        from programmatic_pid.dxf_geometry import spread_instrument_positions
+
+        instruments = [{"id": "A", "x": 0, "y": 0}, {"id": "B", "x": 0, "y": 0}]
+        out = spread_instrument_positions(instruments, min_spacing=2.0)
+        a, b = (out[0]["x"], out[0]["y"]), (out[1]["x"], out[1]["y"])
+        dist = math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2)
+        assert dist >= 2.0 - 0.01
+
+
+# ===========================================================================
+# dxf_arrows
+# ===========================================================================
+
+
+class TestDxfArrowsDirect:
+    """Import directly from dxf_arrows."""
+
+    def test_add_arrow_head_solid(self, msp):
+        from programmatic_pid.dxf_arrows import add_arrow_head
+
+        add_arrow_head(msp, (0, 0), (10, 0), "0")
+        solids = [e for e in msp if e.dxftype() == "SOLID"]
+        assert len(solids) == 1
+
+    def test_add_arrow_line_and_solid(self, msp):
+        from programmatic_pid.dxf_arrows import add_arrow
+
+        add_arrow(msp, (0, 0), (10, 0), "0")
+        assert any(e.dxftype() == "LINE" for e in msp)
+        assert any(e.dxftype() == "SOLID" for e in msp)
+
+    def test_add_arrow_with_color(self, msp):
+        from programmatic_pid.dxf_arrows import add_arrow
+
+        add_arrow(msp, (0, 0), (5, 0), "0", color=2)
+        line = next(e for e in msp if e.dxftype() == "LINE")
+        assert line.dxf.color == 2
+
+    def test_add_poly_arrow_polyline_and_solid(self, msp):
+        from programmatic_pid.dxf_arrows import add_poly_arrow
+
+        add_poly_arrow(msp, [(0, 0), (5, 0), (5, 5)], "0")
+        assert any(e.dxftype() == "LWPOLYLINE" for e in msp)
+        assert any(e.dxftype() == "SOLID" for e in msp)
+
+    def test_add_poly_arrow_too_few_points_noop(self, msp):
+        from programmatic_pid.dxf_arrows import add_poly_arrow
+
+        add_poly_arrow(msp, [(0, 0)], "0")
+        assert len(list(msp)) == 0
+
+    def test_add_arrow_head_diagonal(self, msp):
+        from programmatic_pid.dxf_arrows import add_arrow_head
+
+        add_arrow_head(msp, (0, 0), (3, 4), "0", arrow_size=2.0)
+        solids = [e for e in msp if e.dxftype() == "SOLID"]
+        assert len(solids) == 1


### PR DESCRIPTION
## Summary

Closes #58.

- Extracted six single-responsibility sub-modules from the 651-line `dxf_builder.py`:
  - `dxf_math.py` — `to_float`, `clamp`, `text_box`, `rects_overlap`, `closest_point_on_rect`, `dedupe_points`
  - `dxf_text.py` — `parse_alignment`, `wrap_text_lines`, `LabelPlacer`, `add_text`, `add_text_panel`
  - `dxf_layer.py` — `ensure_layer`, `ensure_layers`, `layer_name`
  - `dxf_symbols.py` — `add_box`, `add_hopper`, `add_fan_symbol`, `add_rotary_valve_symbol`, `add_burner_symbol`, `add_bin_symbol`, `draw_equipment_symbol`
  - `dxf_geometry.py` — `equipment_dims`, `equipment_center`, `equipment_side_anchors`, `equipment_anchor`, `nearest_equipment_anchor`, `get_equipment_bounds`, `resolve_endpoint`, `spread_instrument_positions`
  - `dxf_arrows.py` — `add_arrow_head`, `add_arrow`, `add_poly_arrow`
- `dxf_builder.py` is now a thin facade that re-exports every public name unchanged; all existing imports continue to work.
- Added `tests/test_dxf_submodules.py` with 54 new unit tests (one class per sub-module) that import directly from each sub-module.
- Bumped `SPEC.md` to version 0.1.1 (2026-04-16) and updated module descriptions to reflect the new layout.
- All 248 tests pass; ruff and black checks clean.

## Test plan

- [x] All 194 existing tests still pass (`python -m pytest tests/`)
- [x] 54 new direct-import tests for each sub-module pass
- [x] `ruff check src/ tests/ --select E,F,I,W` — no issues
- [x] `black --check src/ tests/` — no issues
- [x] Backward-compatible: `from programmatic_pid.dxf_builder import *` still exports every original name

🤖 Generated with [Claude Code](https://claude.com/claude-code)