### PR TITLE
Re-export TextEntityAlignment from dxf_builder

### DIFF
--- a/src/programmatic_pid/dxf_builder.py
+++ b/src/programmatic_pid/dxf_builder.py
@@ -49,6 +49,7 @@ from programmatic_pid.dxf_symbols import (
 )
 from programmatic_pid.dxf_text import (
     LabelPlacer,
+    TextEntityAlignment,
     add_text,
     add_text_panel,
     parse_alignment,
@@ -72,6 +73,7 @@ __all__ = [
     "parse_alignment",
     "wrap_text_lines",
     "LabelPlacer",
+    "TextEntityAlignment",
     "add_text",
     "add_text_panel",
     # dxf_layer


### PR DESCRIPTION
## Summary
- expose TextEntityAlignment from the dxf_builder compatibility facade
- keep generator imports and existing callers working after the helper split

## Verification
- python -m ruff check src\\ tests\\
- python -m pytest -q tests\\test_refactored_modules.py tests\\test_pid_generation.py tests\\test_pid_integration.py