### PR TITLE
docs(security): add SECURITY.md with vulnerability disclosure policy (#91)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1.0 | :x:                |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability, please follow the responsible disclosure process below.
+
+### GitHub Private Vulnerability Reporting
+
+This repository has [GitHub Private Vulnerability Reporting](https://github.com/D-sorganization/Programmatic-PID/security/advisories) enabled. You can report vulnerabilities directly through GitHub's Security Advisories feature.
+
+### Email Disclosure
+
+Alternatively, you may email the maintainers directly at the contact address listed in the repository profile.
+
+### What to Include
+
+When reporting a vulnerability, please include:
+
+- **Description**: A clear description of the vulnerability
+- **Steps to Reproduce**: Detailed steps to reproduce the issue
+- **Impact**: The potential impact if exploited
+- **Affected Versions**: Which versions are affected
+- **Suggested Fix**: If you have a suggestion for remediation
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours of receiving your report
+- **Initial Assessment**: Within 7 days
+- **Fix and Disclosure**: Within 30 days, depending on severity and complexity
+
+### Security Measures
+
+This repository uses the following security practices:
+
+- **Static Analysis**: `bandit` is run in CI to detect common Python security issues
+- **Dependency Auditing**: `pip-audit` checks for known vulnerabilities in dependencies
+- **Pre-commit Hooks**: Security-focused linting runs before each commit
+
+Thank you for helping keep Programmatic-PID secure.

--- a/scripts/check_ci_policy.py
+++ b/scripts/check_ci_policy.py
@@ -7,7 +7,6 @@ import re
 import sys
 from pathlib import Path
 
-
 EXPECTED_TOOL_REVS = {
     "Black": r"rev:\s*25\.12\.0",
     "Ruff": r"rev:\s*v0\.14\.10",
@@ -17,11 +16,7 @@ EXPECTED_TOOL_REVS = {
 
 def check_tool_versions() -> int:
     config = Path(".pre-commit-config.yaml").read_text(encoding="utf-8")
-    missing = [
-        tool
-        for tool, pattern in EXPECTED_TOOL_REVS.items()
-        if re.search(pattern, config) is None
-    ]
+    missing = [tool for tool, pattern in EXPECTED_TOOL_REVS.items() if re.search(pattern, config) is None]
     if missing:
         for tool in missing:
             print(


### PR DESCRIPTION
Closes #91

## Summary
Adds a SECURITY.md file to provide a documented path for responsible disclosure of vulnerabilities.

## Changes
- Supported versions table (0.1.x currently supported)
- GitHub Private Vulnerability Reporting link
- Email disclosure alternative
- Response timeline expectations (48h acknowledgment, 7d assessment, 30d fix)
- Security measures documentation (bandit, pip-audit, pre-commit)

## Testing
- Verified markdown renders correctly
- All links are valid GitHub URLs

## Security
This is a community-facing security policy complement to the existing CI security tooling.