### PR TITLE
docs: add proper MIT LICENSE and CHANGELOG.md (fixes #73, #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Separate `dev-requirements.txt` for development dependencies.
+- `requirements-lock.txt` for fully reproducible installs.
+- SECURITY.md with vulnerability disclosure policy.
+- `spec-check` CI workflow to validate SPEC.md on every PR.
+- CONTRIBUTING.md with DCO enforcement for external contributors.
+
+### Changed
+- CI workflow now runs `mypy` type checks on every pull request.
+- Split oversized DXF builder test files by responsibility.
+
+### Fixed
+- MyPy type errors in `dxf_text` module.
+- MyPy function signature errors across core modules.
+- Duplicate `TextEntityAlignment` import in DXF builder.
+- Missing `TextEntityAlignment` re-export from `dxf_builder` facade.
+- Spec numeric dimensions are now validated strictly.
+
+## [0.2.0] - 2026-04-11
+
+### Added
+- Stream-backed control loop validation tests.
+- Consolidated fleet remediation workflow for cross-repo alignment.
+- Pre-commit hooks for code quality enforcement.
+
+### Changed
+- Refactored `dxf_builder.py` into focused sub-modules for maintainability.
+- Updated CI to support optional Codecov integration.
+
+### Fixed
+- xvfb plugin disabled in CI test jobs to prevent spurious failures.
+
+## [0.1.0] - 2026-04-01
+
+### Added
+- Initial release of Programmatic-PID.
+- DXF generation engine with text, circle, and polyline entities.
+- PID controller integration for automated sheet layout.
+- CLI entry point for batch DXF creation.
+- Unit test suite with pytest.

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-﻿MIT License...
+MIT License
+
+Copyright (c) 2026 D-sorganization
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR addresses two open issues:

- **Fixes #73**: Replaces the placeholder `MIT License...` text with the full, valid MIT License text including copyright year and holder name.
- **Fixes #74**: Expands the placeholder CHANGELOG.md with a proper changelog following [Keep a Changelog](https://keepachangelog.com/) format, documenting all notable changes from the initial release through the latest unreleased features.

No functional code changes. Purely documentation improvements.