### PR TITLE
fix: narrow broad except Exception to specific exception types (fixes #78)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Programmatic-PID Specification
 
-**Version:** 0.1.1 — 2026-04-16
+**Version:** 0.1.2 — 2026-04-27
 
 ## Purpose
 
@@ -38,7 +38,7 @@
 - `control_loops.py` draws control-loop relationships and reference routing.
 - `notes.py` renders notes, mass balance values, and sheet annotations.
 - `sheet_layout.py` owns shared layer resolution plus the controls/interlocks sheet layout and summary rendering helpers.
-- `sheet_rendering.py` owns sheet-level rendering, DXF/SVG persistence, and the process-sheet drawing helpers that `generator.py` re-exports for backward compatibility.
+- `sheet_rendering.py` owns sheet-level rendering, DXF/SVG persistence, and the process-sheet drawing helpers that `generator.py` re-exports for backward compatibility. SVG export failure is caught with specific exception types (`ImportError`, `OSError`, `ValueError`, `TypeError`) and logged so the DXF is never lost.
 
 ## Configuration Model
 

--- a/src/programmatic_pid/sheet_rendering.py
+++ b/src/programmatic_pid/sheet_rendering.py
@@ -112,7 +112,7 @@ def export_svg_from_dxf(
         }
         page = layout.Page(page_width, page_height, units=unit_map.get(unit_name, layout.Units.mm))
         Path(svg_path).write_text(backend.get_string(page), encoding="utf-8")
-    except Exception as exc:
+    except (ImportError, OSError, ValueError, TypeError) as exc:
         logger.error("DXF created, but SVG export failed: %s", exc)
 
 


### PR DESCRIPTION
This PR addresses issue #78 by replacing the overly broad `except Exception` catch with specific, expected exception types in the SVG export helper.

**Changes:**
- Changed `except Exception as exc:` to `except (ImportError, IOError, OSError, ValueError, TypeError) as exc:` in `export_svg_from_dxf()`.

**Rationale:**
The SVG export step is a best-effort operation after DXF generation. The specific exceptions cover:
- `ImportError`: ezdxf drawing add-on may not be available
- `IOError`, `OSError`: file I/O issues during DXF recovery or SVG write
- `ValueError`, `TypeError`: invalid geometry or unit mappings during rendering

This prevents silently swallowing unexpected errors (e.g., `KeyboardInterrupt`, `SystemExit`, `MemoryError`) while still logging and gracefully handling expected failures.