### PR TITLE
test(coverage): set fail_under = 75 at tier target (Phase 4, EPIC #1140)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,6 @@ target-version = ["py311"]
 
 [tool.coverage.run]
 source = ["programmatic_pid"]
+
+[tool.coverage.report]
+fail_under = 75


### PR DESCRIPTION
## Summary
- Adds `[tool.coverage.report] fail_under = 75` to pyproject.toml
- Tier: Applications (target 75%)
- Baseline coverage is already ~95%, so jumping straight to the tier target of 75% is safe in a single PR

## Phase 4 (EPIC #1140)
Step 1: set tier-aligned coverage floor.

## Test plan
- [ ] CI green (coverage >= 75 trivially since baseline ~95)

🤖 Generated with [Claude Code](https://claude.com/claude-code)