### PR TITLE
ci: nightly workflow with auto-issue on failure (EPIC #1140)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,57 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nightly-tests:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Create isolated Python environment
+        run: |
+          python -m venv .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install --force-reinstall --ignore-installed -r dev-requirements.txt
+          pip install -e .
+
+      - name: Run nightly tests
+        run: python -m pytest -p no:xvfb tests/ -m "not live_simulation" --durations=20
+
+  report-failure:
+    needs: nightly-tests
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File CI failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly CI failure - ${today}`,
+              body: `The scheduled nightly workflow failed.\n\nRun: ${runUrl}\n\nWorkflow: \`${context.workflow}\`\nCommit: \`${context.sha}\``,
+              labels: ['ci-failure', 'nightly'],
+            });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly.yml` scheduled daily at 08:00 UTC (also `workflow_dispatch`).
- Python 3.11 on self-hosted runner; installs runtime + dev deps then `pip install -e .` matching existing CI conventions.
- Runs `pytest -m "not live_simulation" --durations=20`.
- On scheduled failure, auto-files an issue labeled `ci-failure,nightly` linking to the run.

Implements Spec section 9 (nightly CI) under EPIC #1140.

## Test plan
- [ ] Workflow appears in Actions tab after merge
- [ ] Manual `workflow_dispatch` trigger succeeds
- [ ] Issue-creation step verified by intentional failure (deferred / follow-up)

Refs EPIC #1140.