### PR TITLE
ci: caching campaign (per fleet caching audit)

### DIFF
--- a/.github/workflows/Jules-Redundant-Issue-Closer.yml
+++ b/.github/workflows/Jules-Redundant-Issue-Closer.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Close redundant agent issues
         continue-on-error: true

--- a/.github/workflows/Jules-Redundant-PR-Closer.yml
+++ b/.github/workflows/Jules-Redundant-PR-Closer.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Close redundant agent PRs
         continue-on-error: true

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Create isolated Python environment
         run: |
@@ -61,6 +62,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Create isolated Python environment
         run: |
@@ -89,6 +91,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Create isolated Python environment
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Create isolated Python environment
         run: |


### PR DESCRIPTION
Part of the fleet caching campaign. Audit found ~337 hrs/wk total recoverable across the fleet, ~40 hrs/wk in this batch of repos.

This PR adds pip/npm caches where missing. Per-OS cache keys are handled automatically by `actions/setup-{python,node}` built-in cache.

## Stats
- Modified files: 4
- Added pip caches: 6
- Added npm caches: 0

## Constraints honored
- Did not change workflow logic beyond cache directives
- Did not modify files in conflict with open PRs (cache lines are net-new)
- Per-OS keys via built-in setup-* cache mechanism
- All modified YAMLs validated parseable