### PR TITLE
ci: parallelize jobs after pick-runner + fail-fast: false on matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -77,12 +77,12 @@ jobs:
         run: pip-audit -r requirements.txt --progress-spinner=off
 
   tests:
-    needs: quality-gate
     runs-on: self-hosted
     timeout-minutes: 20
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:


### PR DESCRIPTION
Removes `needs: quality-gate` from `tests` job so it can run in parallel with quality-gate, and adds `fail-fast: false` to the matrix so each python-version reports independently.