### PR TITLE
policy(ci): migrate hosted-runner workflows to d-sorg-fleet (keep guard tripwire on hosted)

### DIFF
--- a/.github/workflows/Verify-Issue-Closure.yml
+++ b/.github/workflows/Verify-Issue-Closure.yml
@@ -28,7 +28,7 @@ jobs:
     if: >-
       github.event.issue.state_reason != 'reopened' &&
       github.event.sender.login != 'github-actions[bot]'
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Check for closure evidence
         uses: actions/github-script@v7

--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   guard:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master'
     steps:
       - name: Checkout PR head with full history

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   quality-gate:
-    runs-on: self-hosted
+    runs-on: d-sorg-fleet
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         run: python scripts/check_ci_policy.py no-placeholders
 
   security-scan:
-    runs-on: self-hosted
+    runs-on: d-sorg-fleet
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
         run: pip-audit -r requirements.txt --progress-spinner=off
 
   tests:
-    runs-on: self-hosted
+    runs-on: d-sorg-fleet
     timeout-minutes: 20
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   nightly-tests:
-    runs-on: self-hosted
+    runs-on: d-sorg-fleet
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
     needs: nightly-tests
     if: failure() && github.event_name == 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     permissions:
       issues: write
     steps:

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   spec-freshness:
     name: Verify SPEC.md freshness
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'spec-exempt') }}
     timeout-minutes: 5
 


### PR DESCRIPTION
## Summary

Fleet-wide policy fix: route all CI jobs to the self-hosted `d-sorg-fleet` pool. Zero-tolerance on `ubuntu-latest`, `windows-latest`, `macos-latest`, and bare `self-hosted` labels.

## Files / jobs migrated

| File | Job | From | To |
|---|---|---|---|
| `.github/workflows/anti-phantom-merge.yml` | `guard` | `ubuntu-latest` | `d-sorg-fleet` |
| `.github/workflows/ci-standard.yml` | `quality-gate` | `self-hosted` | `d-sorg-fleet` |
| `.github/workflows/ci-standard.yml` | `security-scan` | `self-hosted` | `d-sorg-fleet` |
| `.github/workflows/ci-standard.yml` | `tests` | `self-hosted` | `d-sorg-fleet` |
| `.github/workflows/nightly.yml` | `nightly-tests` | `self-hosted` | `d-sorg-fleet` |
| `.github/workflows/nightly.yml` | `report-failure` | `ubuntu-latest` | `d-sorg-fleet` |
| `.github/workflows/spec-check.yml` | `spec-freshness` | `ubuntu-latest` | `d-sorg-fleet` |
| `.github/workflows/Verify-Issue-Closure.yml` | `verify-closure` | `ubuntu-latest` | `d-sorg-fleet` |

## Tripwire / intentionally left on hosted

This repository has **no** `local-only-runner-guard.yml` tripwire, so there is nothing intentionally on `ubuntu-latest`.

## Verification

- All 5 edited workflow files parse via `python -c "import yaml; yaml.safe_load(open(...))"`.
- `git diff` shows only `runs-on:` line changes.

## Test plan

- [ ] CI passes on this PR (running on `d-sorg-fleet`).
- [ ] No jobs in workflow runs report routing to hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)